### PR TITLE
Revert "chore(): 保存msg的字节document"

### DIFF
--- a/src/cmap/conn/wire/op_message.rs
+++ b/src/cmap/conn/wire/op_message.rs
@@ -20,7 +20,6 @@ pub struct ReplyOp {
     pub start_from: u32,
     pub number_returned: u32,
     pub documents: Vec<Document>,
-    pub byte_documents: Option<Vec<Vec<u8>>>
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Reverts easyops-cn/mongo-rust-driver#4